### PR TITLE
Override apache thrift version to work with jaeger current version

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -214,6 +214,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7f0faf10af08c962a2bea6c204cfe1d4882fbbd168a564bd4b729b34060be925"
+  inputs-digest = "f1d7235aed1b34cd28db280a92260ebc16348898b9155bcf0b713839c8625d5b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -40,3 +40,7 @@
 [[constraint]]
   branch = "v1.1"
   name = "gopkg.in/tokopedia/logging.v1"
+
+[[override]]
+  name = "github.com/apache/thrift"
+  version = "0.10.0"


### PR DESCRIPTION
Please do `dep ensure -v` again before build